### PR TITLE
fix env var configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ kubectl delete -f bundle.yaml
 Configuration is built through environment variables currently defined in `deploy/operator.yaml`
 Below are the available configuration options
 
-| Environment Variable           | Description                                                      | Default                |
-| ------------------------------ | ---------------------------------------------------------------- | ---------------------- |
-| `MANAGE_ROUTES`                | Maintain routes in VPC route tables for the peering              | `true`                 |
-| `OPERATOR_NAME`                | The name of the operator                                         | `vpc-peering-operator` |
-| `WATCH_ALL_NAMESPACES`         | Override the SDK and listen to events in all namespaces          | `false`                |
-| `OPERATOR_POLLER_RETRIES`      | The amount of retries for waiting for a peering to become active | `5`                    |
-| `OPERATOR_POLLER_WAIT_SECONDS` | The number of seconds to wait between retries                    | `60`                   |
-| `WATCH_NAMESPACE`              | The namespace to watch for CRD events                            | `metadata.namespace`   |
+| Environment Variable   | Description                                                      | Default                |
+| ---------------------- | ---------------------------------------------------------------- | ---------------------- |
+| `MANAGE_ROUTES`        | Maintain routes in VPC route tables for the peering              | `true`                 |
+| `OPERATOR_NAME`        | The name of the operator                                         | `vpc-peering-operator` |
+| `WATCH_ALL_NAMESPACES` | Override the SDK and listen to events in all namespaces          | `false`                |
+| `POLLER_RETRIES`       | The amount of retries for waiting for a peering to become active | `5`                    |
+| `POLLER_WAIT_SECONDS`  | The number of seconds to wait between retries                    | `60`                   |
+| `WATCH_NAMESPACE`      | The namespace to watch for CRD events                            | `metadata.namespace`   |

--- a/cmd/vpc-peering-operator/main.go
+++ b/cmd/vpc-peering-operator/main.go
@@ -50,7 +50,7 @@ func init() {
 	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	logger.Log("msg", "Starting VPC Peering Operator version", "version", version)
 
-	if err := envconfig.InitWithPrefix(&cfg, "OPERATOR"); err != nil {
+	if err := envconfig.Init(&cfg); err != nil {
 		level.Error(logger).Log("msg", "Error loading config: %s", "err", err.Error())
 	}
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,10 +16,10 @@ spec:
         - name: vpc-peering-operator
           image: quay.io/pickledrick/vpc-peering-operator
           ports:
-          - containerPort: 60000
-            name: metrics
+            - containerPort: 60000
+              name: metrics
           command:
-          - vpc-peering-operator
+            - vpc-peering-operator
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
 #4 Removes envconfig prefix as not really necessary and tidy up documentation + deploy example